### PR TITLE
Fix UT failure

### DIFF
--- a/pkg/nodeupdater/utils_test.go
+++ b/pkg/nodeupdater/utils_test.go
@@ -109,7 +109,7 @@ func TestGetAccessToken(t *testing.T) {
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)
 		_, err := tc.secretConfig.GetAccessToken(logger)
-		if err != nil {
+		if err != nil && tc.expErr != nil {
 			if err.Error() != tc.expErr.Error() && !strings.Contains(err.Error(), tc.expErr.Error()) {
 				t.Fatalf("Expected error code: %v, got: %v. err : %v", tc.expErr, err, err)
 			}
@@ -199,6 +199,7 @@ func TestCheckIfRequiredLabelsPresent(t *testing.T) {
 	exp := CheckIfRequiredLabelsPresent(labelMap)
 	assert.Equal(t, exp, false)
 	labelMap[vpcBlockLabelKey] = "true"
+	labelMap[instanceIDLabelKey] = "true"
 	ex := CheckIfRequiredLabelsPresent(labelMap)
 	assert.Equal(t, ex, true)
 }


### PR DESCRIPTION
To Fix: https://github.com/IBM/vpc-node-label-updater/issues/10 and time being unblock merging of https://github.com/openshift/ibm-vpc-node-label-updater/pull/11

Point 2  is not taken care of in this PR but can be raised as a separate PR .

```
We need to fix the "valid request" test case. Obviously we can't add valid credentials to the unit test, so perhaps that endpoint needs to be mocked out somehow.
```