### PR TITLE
Fix unit tests and golint issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0 h1:i5VIxp6QB8oWZ8IkK8zrDgeT6ORGIUeiN+61iETwJbI=
+github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0/go.mod h1:4xpMLz7RBWyB+ElzHu8Llua96TRCB3YwX+l5EP1wmHk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/nodeupdater/utils.go
+++ b/pkg/nodeupdater/utils.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	errors "errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -171,7 +171,7 @@ func (c *VpcNodeLabelUpdater) GetInstancesFromVPC(riaasInstanceURL *url.URL) ([]
 	}
 	defer instanceResponse.Body.Close()
 	// read response body
-	instance, err := ioutil.ReadAll(instanceResponse.Body)
+	instance, err := io.ReadAll(instanceResponse.Body)
 	if err != nil {
 		c.Logger.Error("Failed to read response body of instance details from riaas provider", zap.Error(err))
 		return nil, err

--- a/pkg/nodeupdater/utils.go
+++ b/pkg/nodeupdater/utils.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-//Package nodeupdater ...
+// Package nodeupdater ...
 package nodeupdater
 
 import (
@@ -40,7 +40,6 @@ const (
 	failureZoneLabelKey    = "failure-domain.beta.kubernetes.io/zone"
 	topologyRegionLabelKey = "topology.kubernetes.io/region"
 	topologyZoneLabelKey   = "topology.kubernetes.io/zone"
-	configFileName         = "slclient.toml"
 	vpcGeneration          = "2"
 	vpcRiaasVersion        = "2020-01-01"
 	maxAttempts            = 30

--- a/pkg/nodeupdater/utils_test.go
+++ b/pkg/nodeupdater/utils_test.go
@@ -56,28 +56,6 @@ func TestReadSecretConfiguration(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-type testConfig struct {
-	Header sectionTestConfig
-}
-
-type sectionTestConfig struct {
-	ID      int
-	Name    string
-	YesOrNo bool
-	Pi      float64
-	List    string
-}
-
-var testConf = testConfig{
-	Header: sectionTestConfig{
-		ID:      1,
-		Name:    "test",
-		YesOrNo: true,
-		Pi:      3.14,
-		List:    "1, 2",
-	},
-}
-
 func TestCheckIfRequiredLabelsPresent(t *testing.T) {
 	labelMap := make(map[string]string)
 	exp := CheckIfRequiredLabelsPresent(labelMap)

--- a/pkg/nodeupdater/utils_test.go
+++ b/pkg/nodeupdater/utils_test.go
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-//Package nodeupdater ...
+// Package nodeupdater ...
 package nodeupdater
 
 import (
 	errors "errors"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -54,11 +52,7 @@ func TestReadSecretConfiguration(t *testing.T) {
 	logger, teardown := GetTestLogger(t)
 	defer teardown()
 
-	if err != nil {
-		t.Errorf("This test will fail because of %v", err)
-	}
-
-	_, err = ReadSecretConfiguration(logger)
+	_, err := ReadSecretConfiguration(logger)
 	assert.NotNil(t, err)
 }
 


### PR DESCRIPTION
There are several commits in this PR, which fix `make` with go v1.19.

* Fix unit tests code.
* Remove unused variables + types.
* Remove deprecated ioutil package usage.